### PR TITLE
✨ feat : 수급자관리 (#97)

### DIFF
--- a/src/main/java/org/ateam/oncare/beneficiary/command/controller/CareLevelExpirationCommandController.java
+++ b/src/main/java/org/ateam/oncare/beneficiary/command/controller/CareLevelExpirationCommandController.java
@@ -33,8 +33,9 @@ public class CareLevelExpirationCommandController {
      */
     @PostMapping("/expirations/{expirationId}/notices/absent")
     public void recordAbsent(@PathVariable Integer expirationId,
-                             @RequestParam Integer empId) {
-        service.recordAbsent(expirationId, empId);
+                             @RequestParam Integer empId,
+                             @RequestParam(required = false) String noticeDate) {
+        service.recordAbsent(expirationId, empId, noticeDate);
     }
 
     /**

--- a/src/main/java/org/ateam/oncare/beneficiary/command/dto/request/CreateNoticeRequest.java
+++ b/src/main/java/org/ateam/oncare/beneficiary/command/dto/request/CreateNoticeRequest.java
@@ -8,8 +8,7 @@ import lombok.Setter;
 @Getter
 @Setter
 public class CreateNoticeRequest {
-    // "2025-12-16 10:00:00" 같은 문자열로 받거나 프론트에서 ISO로 보내도 됨
-    private String noticeDate;
+    private String noticeDate; // 프론트에서 직접입력하면 받는 날짜
     private String memo;
     private Integer empId;
 }

--- a/src/main/java/org/ateam/oncare/beneficiary/command/service/CareLevelExpirationCommandService.java
+++ b/src/main/java/org/ateam/oncare/beneficiary/command/service/CareLevelExpirationCommandService.java
@@ -1,5 +1,8 @@
 package org.ateam.oncare.beneficiary.command.service;
 
+// 현재탭: noticeDate null -> NOW()
+// 직접입력탭: noticeDate 값 -> 그 시간으로 업데이트
+
 import lombok.RequiredArgsConstructor;
 import org.ateam.oncare.beneficiary.command.dto.request.CreateNoticeRequest;
 import org.ateam.oncare.beneficiary.command.dto.request.UpdateExtendsStatusRequest;
@@ -25,13 +28,8 @@ public class CareLevelExpirationCommandService {
      * - outbound_status = 'N'
      */
     @Transactional
-    public void recordAbsent(Integer expirationId, Integer empId) {
-        mapper.insertNotice(
-                expirationId,
-                null,
-                "연락 시도했으나 부재중. 추후 재연락 필요.",
-                empId
-        );
+    public void recordAbsent(Integer expirationId, Integer empId, String noticeDate) {
+        mapper.insertNotice(expirationId, noticeDate, "연락 시도했으나 부재중. 추후 재연락 필요.", empId);
         mapper.updateOutboundStatus(expirationId, "N");
     }
 
@@ -42,17 +40,14 @@ public class CareLevelExpirationCommandService {
      */
     @Transactional
     public void completeNotice(Integer expirationId, CreateNoticeRequest req) {
-        mapper.insertNotice(
-                expirationId,
-                req.getNoticeDate(),
-                req.getMemo(),
-                req.getEmpId()
-        );
+        mapper.insertNotice(expirationId, req.getNoticeDate(), req.getMemo(), req.getEmpId());
         mapper.updateOutboundStatus(expirationId, "Y");
     }
 
     @Transactional
     public int updateNotice(Integer expirationId, Integer noticeId, UpdateNoticeRequest req) {
+        // 현재탭: noticeDate null -> NOW()
+        // 직접입력탭: noticeDate 값 -> 그 시간으로 업데이트
         return mapper.updateNotice(expirationId, noticeId, req.getNoticeDate(), req.getMemo(), req.getEmpId());
     }
 

--- a/src/main/java/org/ateam/oncare/beneficiary/query/controller/CareLevelExpirationQueryController.java
+++ b/src/main/java/org/ateam/oncare/beneficiary/query/controller/CareLevelExpirationQueryController.java
@@ -1,7 +1,5 @@
 package org.ateam.oncare.beneficiary.query.controller;
 
-/* 장기요양등급만료알림 조회부분 controller */
-
 import lombok.RequiredArgsConstructor;
 import org.ateam.oncare.beneficiary.query.dto.response.CareLevelExpirationDetailResponse;
 import org.ateam.oncare.beneficiary.query.dto.response.CareLevelExpirationListResponse;
@@ -19,10 +17,16 @@ public class CareLevelExpirationQueryController {
     /**
      * 1) 만료 예정 전체조회
      * - section: 1(90일), 2(60일), 3(45일), null이면 전체
+     * - extendsStatus: (옵션)
+     *    null/미전달 -> 기존대로 (Y 또는 NULL)만
+     *    N -> 미연장 리스트만
      */
     @GetMapping
-    public CareLevelExpirationListResponse getList(@RequestParam(required = false) Integer section) {
-        return service.getExpirationList(section);
+    public CareLevelExpirationListResponse getList(
+            @RequestParam(required = false) Integer section,
+            @RequestParam(required = false) String extendsStatus
+    ) {
+        return service.getExpirationList(section, extendsStatus);
     }
 
     /**

--- a/src/main/java/org/ateam/oncare/beneficiary/query/dto/response/NoticeExpirationListResponse.java
+++ b/src/main/java/org/ateam/oncare/beneficiary/query/dto/response/NoticeExpirationListResponse.java
@@ -20,5 +20,6 @@ public class NoticeExpirationListResponse {
         private String noticeDate; // yyyy-MM-dd HH:mm:ss
         private String memo;
         private Integer empId;
+        private String empName;
     }
 }

--- a/src/main/java/org/ateam/oncare/beneficiary/query/mapper/CareLevelExpirationQueryMapper.java
+++ b/src/main/java/org/ateam/oncare/beneficiary/query/mapper/CareLevelExpirationQueryMapper.java
@@ -1,6 +1,5 @@
 package org.ateam.oncare.beneficiary.query.mapper;
 
-
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.ateam.oncare.beneficiary.query.dto.response.CareLevelExpirationDetailResponse;
@@ -12,9 +11,10 @@ import java.util.List;
 @Mapper
 public interface CareLevelExpirationQueryMapper {
 
-    /* 전체조회 */
+    /* 전체조회 (section + extendsStatus optional) */
     List<CareLevelExpirationListResponse.Item> selectExpirationList(
-            @Param("section") Integer section
+            @Param("section") Integer section,
+            @Param("extendsStatus") String extendsStatus
     );
 
     /* 상세조회 */

--- a/src/main/java/org/ateam/oncare/beneficiary/query/service/CareLevelExpirationQueryService.java
+++ b/src/main/java/org/ateam/oncare/beneficiary/query/service/CareLevelExpirationQueryService.java
@@ -1,7 +1,6 @@
 package org.ateam.oncare.beneficiary.query.service;
 
 import lombok.RequiredArgsConstructor;
-import org.ateam.oncare.alarm.command.service.NotificationCommandService;
 import org.ateam.oncare.beneficiary.query.dto.response.CareLevelExpirationDetailResponse;
 import org.ateam.oncare.beneficiary.query.dto.response.CareLevelExpirationListResponse;
 import org.ateam.oncare.beneficiary.query.dto.response.NoticeExpirationListResponse;
@@ -15,17 +14,19 @@ import java.util.List;
 public class CareLevelExpirationQueryService {
 
     private final CareLevelExpirationQueryMapper mapper;
-//    private final NotificationCommandService commandService;
 
     /**
      * 1) 만료 예정 전체조회
      * - section: 1(90일), 2(60일), 3(45일), null이면 전체
+     * - extendsStatus:
+     *    null/"" -> 기본(Y 또는 NULL) (기존 동작 유지)
+     *    "N"     -> 미연장 리스트
+     *    "Y"     -> 연장 예정만 (원하면)
      */
-    public CareLevelExpirationListResponse getExpirationList(Integer section) {
-        List<CareLevelExpirationListResponse.Item> items = mapper.selectExpirationList(section);
+    public CareLevelExpirationListResponse getExpirationList(Integer section, String extendsStatus) {
+        List<CareLevelExpirationListResponse.Item> items = mapper.selectExpirationList(section, extendsStatus);
         CareLevelExpirationListResponse res = new CareLevelExpirationListResponse();
         res.setItems(items);
-
         return res;
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,8 @@ spring:
     url: jdbc:mariadb://${RDS_HOSTNAME}:${RDS_PORT}/${RDS_DB_NAME}
     username: ${RDS_USERNAME}
     password: ${RDS_PASSWORD}
+    jackson:
+      time-zone: Asia/Seoul
 
   jpa:
     generate-ddl: false
@@ -15,6 +17,8 @@ spring:
     properties:
       hibernate:
         '[format_sql]' : true
+        jdbc:
+          time_zone: Asia/Seoul
 
 jwt:
   access-secret: ${JWT_AT_SECRET}

--- a/src/main/resources/org/ateam/oncare/beneficiary/command/mapper/CareLevelExpirationCommandMapper.xml
+++ b/src/main/resources/org/ateam/oncare/beneficiary/command/mapper/CareLevelExpirationCommandMapper.xml
@@ -47,14 +47,14 @@
                 #{noticeDate}
             </when>
             <otherwise>
-                notice_date
+                NOW()
             </otherwise>
         </choose>
         ,
         memo = #{memo},
         emp_id = #{empId}
         WHERE id = #{noticeId}
-            AND expiration_id = #{expirationId}
+        AND expiration_id = #{expirationId}
     </update>
 
     <!-- 안내이력 삭제 -->

--- a/src/main/resources/org/ateam/oncare/beneficiary/query/mapper/CareLevelExpirationQueryMapper.xml
+++ b/src/main/resources/org/ateam/oncare/beneficiary/query/mapper/CareLevelExpirationQueryMapper.xml
@@ -5,7 +5,7 @@
 
 <mapper namespace="org.ateam.oncare.beneficiary.query.mapper.CareLevelExpirationQueryMapper">
 
-    <!-- 1) 만료 예정 전체조회(섹션 필터 optional) -->
+    <!-- 1) 만료 예정 전체조회(섹션 필터 optional + extendsStatus optional) -->
     <select id="selectExpirationList"
             resultType="org.ateam.oncare.beneficiary.query.dto.response.CareLevelExpirationListResponse$Item">
 
@@ -25,6 +25,8 @@
         e.name AS careWorkerName,
 
         IFNULL(ne.noticeCount, 0) AS noticeCount,
+
+        <!-- DB가 KST면 변환하지 말고 그대로 포맷 -->
         DATE_FORMAT(ne.lastNoticeDate, '%Y-%m-%d %H:%i:%s') AS lastNoticeDate,
 
         CASE
@@ -39,13 +41,12 @@
         JOIN beneficiary_care_level bcl
         ON bcl.beneficiary_id = b.id
 
-        /* ✅ DONE 방문 중 가장 최근 1건을 대표 방문으로 선택 */
+        /* 가장 최근 1건을 대표 방문으로 선택 */
         LEFT JOIN visit_schedule vs_done
         ON vs_done.vs_id = (
         SELECT vs2.vs_id
         FROM visit_schedule vs2
         WHERE vs2.beneficiary_id = b.id
-<!--        AND vs2.visit_status = 'DONE'-->
         ORDER BY vs2.start_dt DESC
         LIMIT 1
         )
@@ -53,7 +54,7 @@
         LEFT JOIN care_worker cw
         ON cw.id = vs_done.care_worker_id
 
-        <!-- ✅ care_worker에는 name이 없으므로 employee에서 이름 조회 -->
+        /* care_worker에는 name이 없으므로 employee에서 이름 조회 */
         LEFT JOIN employee e
         ON e.id = cw.employee_id
 
@@ -66,12 +67,18 @@
         GROUP BY expiration_id
         ) ne ON ne.expiration_id = ecl.id
 
-        <!-- extends_status
-          Y : 연장 예정 (만료 알림 목록 포함)
-          N : 연장 안 함 (만료 알림 목록 제외) -->
         WHERE 1=1
         AND ecl.expired_section IN (1,2,3)
-        AND (ecl.extends_status IS NULL OR ecl.extends_status = 'Y')
+
+        <!-- 핵심: extendsStatus 파라미터가 없으면(기본) 기존처럼 Y/NULL만 -->
+        <if test="extendsStatus == null or extendsStatus == ''">
+            AND (ecl.extends_status IS NULL OR ecl.extends_status = 'Y')
+        </if>
+
+        <!-- extendsStatus가 들어오면 해당 값만 -->
+        <if test="extendsStatus != null and extendsStatus != ''">
+            AND ecl.extends_status = #{extendsStatus}
+        </if>
 
         <if test="section != null">
             AND ecl.expired_section = #{section}
@@ -105,7 +112,7 @@
         g.phone AS guardianPhone,
         g.relation AS guardianRelation,
 
-        /* ✅ 장기요양등급 */
+        /* 장기요양등급 */
         mcl.id AS careLevelId,
         mcl.level AS careLevel
 
@@ -113,18 +120,14 @@
         JOIN beneficiary b
         ON b.id = ecl.beneficiary_id
 
-
-        /* ✅ 여기서 bcl을 가져오고 있으니 bcl.id로 등급 조인 가능 */
         JOIN beneficiary_care_level bcl
         ON bcl.beneficiary_id = b.id
 
-        /* ✅ DONE 방문 중 가장 최근 1건을 대표 방문으로 선택 */
         LEFT JOIN visit_schedule vs_done
         ON vs_done.vs_id = (
         SELECT vs2.vs_id
         FROM visit_schedule vs2
         WHERE vs2.beneficiary_id = b.id
-<!--        AND vs2.visit_status = 'DONE'-->
         ORDER BY vs2.start_dt DESC
         LIMIT 1
         )
@@ -132,7 +135,6 @@
         LEFT JOIN care_worker cw
         ON cw.id = vs_done.care_worker_id
 
-        <!-- ✅ care_worker에는 name이 없으므로 employee에서 이름 조회 -->
         LEFT JOIN employee e
         ON e.id = cw.employee_id
 
@@ -140,19 +142,14 @@
         ON g.beneficiary_id = b.id
         AND g.is_primary = 'Y'
 
-        /* ✅ 등급 조인 추가 */
         LEFT JOIN beneficiary_count bc
         ON bc.beneficiary_care_level_id = bcl.id
 
         LEFT JOIN m_care_level mcl
         ON mcl.id = bc.m_care_level_id
 
-        <!-- extends_status
-          Y : 연장 예정 (만료 알림 목록 포함)
-          N : 연장 안 함 (만료 알림 목록 제외) -->
         WHERE ecl.id = #{expirationId}
         AND ecl.expired_section IN (1,2,3)
-        AND (ecl.extends_status IS NULL OR ecl.extends_status = 'Y')
         LIMIT 1
     </select>
 
@@ -162,13 +159,20 @@
             resultType="org.ateam.oncare.beneficiary.query.dto.response.NoticeExpirationListResponse$Item">
 
         SELECT
-        id AS noticeId,
-        DATE_FORMAT(notice_date, '%Y-%m-%d %H:%i:%s') AS noticeDate,
-        memo AS memo,
-        emp_id AS empId
-        FROM notice_expiration
-        WHERE expiration_id = #{expirationId}
-        ORDER BY notice_date DESC, id DESC
+        ne.id AS noticeId,
+        <!-- DB가 KST면 변환하지 말고 그대로 포맷 -->
+        DATE_FORMAT(ne.notice_date, '%Y-%m-%d %H:%i:%s') AS noticeDate,
+        ne.memo AS memo,
+        ne.emp_id AS empId,
+        <!-- 직원 이름 추가 -->
+        e.name AS empName
+
+        FROM notice_expiration ne
+        LEFT JOIN employee e
+        ON ne.emp_id = e.id
+
+        WHERE ne.expiration_id = #{expirationId}
+        ORDER BY ne.notice_date DESC, ne.id DESC
     </select>
 
 </mapper>


### PR DESCRIPTION
## 📝 PR 내용
- 장기요양등급 탭(부재중/미완료, 안내등록, 수정) 시간에 관해 서버 KCT로 수정
- 장기요양등급 등록부분에서 '현재' 탭은 백엔드 시간에서 호출, '직접입력' 탭은 프론트에서 백엔드로 받음
- 장기요양등급 탭에서 등급 미연장 리스트 생성
- 장기요양등급 상세 탭에서 안내이력에 직원이름 추가
- yml파일에 서버 KCT시간 추가

## 📮 관련 이슈 번호
- #97 

## ✨ 변경 유형
- [x] 신규 기능 추가 (New Feature)
- [ ] 버그 수정 (Bug Fix)
- [x] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation)
- [ ] 기타 (Typo, Config, etc.)

## 📢 특이사항

## ✅ 체크리스트
- [x] **PR 대상 브랜치가 main이 아닌지 확인했나요?** (Feature 브랜치 등)
- [x] 관련 이슈를 연결했나요?
- [x] 로컬 환경에서 테스트를 통해 동작을 확인했나요?
